### PR TITLE
fix: gatsby preview support

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -39,7 +39,7 @@ module.exports = {
 				async ({ id, language, translations, uri }) =>
 					await createPage({
 						component: require.resolve("./src/templates/page.tsx"),
-						context: { pageId: id, language, uri, translations },
+						context: { id, language, uri, translations },
 						path: uri,
 					})
 			)

--- a/src/templates/page.tsx
+++ b/src/templates/page.tsx
@@ -72,8 +72,8 @@ class PageTemplate extends React.Component<Props> {
 export default PageTemplate;
 
 export const query = graphql`
-	query PageTemplateQuery($pageId: String!) {
-		page: wpPage(id: { eq: $pageId }) {
+	query PageTemplateQuery($id: String!) {
+		page: wpPage(id: { eq: $id }) {
 			content
 			id
 			isFrontPage

--- a/src/utils/layout.util.tsx
+++ b/src/utils/layout.util.tsx
@@ -1,4 +1,4 @@
-import { ISiteContext, SitePageTranslations } from "../types/site.types";
+import { ISiteContext, SiteTranslations } from "../types/site.types";
 import { SiteContext, defaultSiteContext } from "../context/site.context";
 import { WpLang, WpPage } from "../types/wordpress.types";
 import { Helmet } from "react-helmet";
@@ -23,7 +23,7 @@ export const wrapPageElement = ({
 	element,
 	props,
 }: Props): React.ReactElement => {
-	const translations: SitePageTranslations = {};
+	const translations: SiteTranslations = {};
 	props.pageContext.translations?.forEach(translation => {
 		if (translation.language && translation.uri) {
 			translations[translation.language.code] = {


### PR DESCRIPTION
For Gatsby Preview to work, the `id` item needs to be set in `pageContext`; this addresses that requirement.